### PR TITLE
Upgrade numpy to support python 3.8 and remove non-existing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,10 @@ jdcal==1.4.1
 kiwisolver==1.1.0
 matplotlib==3.1.1
 more-itertools==7.2.0
-numpy==1.17.1
+numpy==1.17.4
 odfpy==1.4.0
 openpyxl==2.6.3
 packaging==19.1
-pkg-resources==0.0.0
 pluggy==0.12.0
 psutil==5.6.3
 py==1.8.0


### PR DESCRIPTION
Hi, and thanks for making this software! I tried to run it from source but `pip install -r requirements.txt` failed with python 3.8. [Numpy 1.17.1 (from the requirements file) doesn't support python 3.8](https://github.com/numpy/numpy/releases/tag/v1.17.1) and pip couldn't find `pkg-resources==0.0.0`. I couldn't find it either on pypi. After upgrading numpy and removing the non-existing package installation completed smoothly and the software seems to work fine.