### PR TITLE
Adding indentation to provide diffability and gitability of project files

### DIFF
--- a/boris/core.py
+++ b/boris/core.py
@@ -9163,7 +9163,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             else:  # .boris and other extensions
                 with open(projectFileName, "w") as f_out:
                     # f_out.write(json.dumps(self.pj, indent=1, separators=(",", ":"), default=decimal_default))
-                    f_out.write(json.dumps(self.pj, default=decimal_default))
+                    f_out.write(json.dumps(self.pj, indent=1, default=decimal_default))
 
             self.projectChanged = False
             self.save_project_json_started = False


### PR DESCRIPTION
I realize there was a commented line with a similar setting once I found it, but I thought making a PR might be a good way of communicating why I think the change would be very beneficial.

**Tldr: for being able to make meaningful diffs and in turn, being able to meaningfully version control a project file via git.**

In the current implementation the entire output file is a single line, which diffing any change will print the entire contents. Adding the smallest of indents makes both diff and line-based version control usable, which would greatly increase quality control and sharing possibilities of a boris project.

The only downside I can think of would be a file size increase of about 50%, but I have two arguments why I don't think this matters:
- we're talking of size going from ~500K to ~750K, which even with a LOT of boris project files should be negligible, beside a single video that was coded with Boris
- if you do use git for versioning a boris project file after the first change you would actually gain space, since with the current version git would rewrite the entire single line, essentially duplicating the file, while with the indent it would just change that one small line. The sample file (which with indent is ~750K) consists of 56K lines, so most edits would be unnoticeably small compared to not having indents.