### PR TITLE
Append a tuple instead of a list for not-observed behaviors

### DIFF
--- a/boris/time_budget_functions.py
+++ b/boris/time_budget_functions.py
@@ -191,7 +191,7 @@ def synthetic_time_budget_bin(pj: dict, selected_observations: list, parameters_
         # add selected behaviors that are not observed
         for behav in selected_behaviors:
             if [x for x in distinct_behav_modif if x[0] == behav] == []:
-                distinct_behav_modif.append([behav, ""])
+                distinct_behav_modif.append((behav, ""))
         '''
         print("distinct_behav_modif with not observed behav", distinct_behav_modif)
         '''


### PR DESCRIPTION
Fixes #548 

As detailed in #548, currently a **list** is appended for behaviors that are not observed. This results in a `unhashable type: 'list'` in `init_behav_modif_bin()` when trying to use that as a dict key.
After switching to a tuple, I can successfully export a synthetic time budget with time bin analysis for all behaviors, including those without any observed event.

Thanks for your time considering this PR; I'll be happy to run more test as needed/requested.