### PR TITLE
Make BORIS more git-friendly by adding indentation in project files

### DIFF
--- a/boris/core.py
+++ b/boris/core.py
@@ -2762,10 +2762,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         try:
             if projectFileName.endswith(".boris.gz"):
                 with gzip.open(projectFileName, mode="wt", encoding="utf-8") as f_out:
-                    f_out.write(json.dumps(self.pj, default=util.decimal_default))
+                    f_out.write(json.dumps(self.pj, default=util.decimal_default, indent=2))
             else:  # .boris and other extensions
                 with open(projectFileName, "w") as f_out:
-                    f_out.write(json.dumps(self.pj, default=util.decimal_default))
+                    f_out.write(json.dumps(self.pj, default=util.decimal_default, indent=2))
 
             self.projectChanged = False
             menu_options.update_windows_title(self)


### PR DESCRIPTION
.boris Files have json structure without indentation, ie. the whole file has one line only. This makes them hard to use with git, because every change in a project file results in merging conflicts. This pull request solves this problem by adding indentation to the save command. If a team works with BORIS using git version control, the change allows them to e.g. add observations and subjects with individual commits.