### PR TITLE
setup.py: declare dependency on Python 3.8 or later (#563)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "Source code": "https://github.com/olivierfriard/BORIS",
         "Issues": "https://github.com/olivierfriard/BORIS/issues",
     },
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "Topic :: Scientific/Engineering",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
As mentioned on issue #563, `setup.py` declares a requirement on Python 3.6 or later but BORIS is actually dependent on Python 3.8 or later. This is checked again at runtime in `boris/core.py`. This commit just fixes the check during installation.