### PR TITLE
Fix end time of Needleman-Wunsch analysis

### DIFF
--- a/boris/irr.py
+++ b/boris/irr.py
@@ -500,7 +500,7 @@ def needleman_wunsch_identity(
 
     last_event = cursor.execute(
         (
-            "SELECT max(start) FROM aggregated_events "
+            "SELECT max(stop) FROM aggregated_events "
             f"WHERE observation in (?, ?) AND subject in ({','.join('?'*len(selected_subjects))}) "
         ),
         (obsid1, obsid2) + tuple(selected_subjects),


### PR DESCRIPTION
The current Needleman-Wunsch analysis only takes into account the latest *start* time of the events, which seems wrong, especially given the comparison to the same lines for [Cohen's kappa](https://github.com/olivierfriard/BORIS/blob/27047eb1c9fb6740aac9cac13f831a5b1afebbdc/boris/irr.py#L136-L142).