### PR TITLE
Add macOS startup script

### DIFF
--- a/scripts/start_macOS.command
+++ b/scripts/start_macOS.command
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+
+####################################################################################
+# Automates BORIS startup on macOS                                                 #
+#                                                                                  #
+# 1. Install Docker Desktop (https://docs.docker.com/desktop/install/mac-install/) #
+# 2. Install XQuartx (https://www.xquartz.org) *and* reboot                        #
+# 3. Save this script using "Raw" button                                           #
+# 4. In Terminal app type "chmod +x start_macOS.command"                           #
+# 5. Double-click the script to start BORIS                                        #
+#                                                                                  #
+####################################################################################
+
+# You can but shouldn't need to modify these locations
+XAUTH=/tmp/.docker.xauth
+BORIS_HOME="${HOME}/Boris"
+
+
+###
+### Do NOT modify anything below this line
+###
+ret=0
+docker info >/dev/null 2>&1 || ret=$?
+if [[ $ret -eq 0 ]]; then
+    echo "[+] Docker Engine is running"
+else
+    echo "[-] Docker Engine is not running or is not responding!"
+    exit 1
+fi
+
+# We need to check for that specific binary; there are mutliple "xquartz" hits during startup
+# If checked for just "xquartz" it will match before the TCP is fully initialized and fail later
+isXQuartzRunning () {
+    local xqProcesses
+    xqProcesses=$(ps aux | grep -v grep | grep -c -i '/opt/X11/bin/Xquartz')
+    if [[ $xqProcesses -gt 0 ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if ! isXQuartzRunning; then
+    echo "[*] XQuartz not running, starting..."
+    echo "[*] You CAN close the new WHITE terminal window once it opens"
+
+    # There's no way to await until XQ *starts* with "open"
+    # We can however wait for the main XQ process to start
+    open -j -g /Applications/Utilities/XQuartz.app   
+    xqStarted=0
+    echo -n "[*] Awaiting XQuartz..."
+    for i in {0..60}; do
+        if isXQuartzRunning; then
+            echo " [OK]"
+            xqStarted=1
+            break
+        fi
+
+        echo -n "."
+        sleep 1
+    done
+    if [[ $xqStarted -ne 1 ]]; then
+      echo " [TIMEOUT]"
+      echo "[!] XQuartz failed to start after 60s. Make sure it is installed properly and you restarted your computer after installation!"
+      exit 1
+    fi
+
+    # Sometimes the TCP socket isn't active right away - there's no easy way to wait for that
+    sleep 2
+fi
+
+# XQuartz (for security reasons) does NOT listen on TCP by default
+# It needs to be enabled manually by the user in XQ preferences; sometimes it resets after update
+netstat -an | grep LISTEN | grep '*.6000' >/dev/null 2>&1 || ret=$?
+if [[ $ret -eq 0 ]]; then
+    echo "[+] XQuartz TCP is enabled"
+else
+    echo '[-] XQuartz is running but it is NOT configured properly! You need to enable "Allow connections from network clients" in XQuartz preferences'
+    exit 1
+fi
+
+# On first run the home may not exist
+mkdir -p "${BORIS_HOME}"
+echo "This folder contains hidden files. Deleting it will remove all settings and other BORIS data!" > "${BORIS_HOME}/_DO_NOT_DELETE_THIS_FOLDER_.txt"
+
+# The XAUTHORITY file content will change for security reasons every time the XQuartz is restarte
+# We're using "magic cookie" instead of host auth as internal container IP is ephemeral and "random"
+# Using "host" network is discouraged for security reasons
+echo "[*] Preparing X11 authorization..."
+rm $XAUTH >/dev/null 2>&1 || true
+touch "${XAUTH}"
+xauth nlist "$(hostname):0" | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+echo
+echo
+echo "==========================================================="
+echo "[*] Starting BORIS..."
+echo "[*] DO NOT CLOSE THIS TERMINAL WINDOW BEFORE CLOSING BORIS!"
+echo "==========================================================="
+echo 
+echo
+docker run \
+  -e "DISPLAY=host.docker.internal:0" \
+  -v "$XAUTH:$XAUTH" \
+  -e "XAUTHORITY=$XAUTH" \
+  -v "${BORIS_HOME}:/root:rw" \
+ olivierfriard/boris
+
+echo "[*] Cleaning-up..."
+rm $XAUTH
+
+echo
+echo
+echo "[+] YOU CAN CLOSE THIS WINDOW NOW"


### PR DESCRIPTION
### Rationale
macOS is a popular platform in academia. Running any Linux GUI apps on macOS via Docker is rather complicated, and ridden with possible security issues. This script serves as one-stop-shop for running BORIS on modern macOS installations.

### Why & how?
1. The script targets researchers rather than developers, i.e. it tries to communicate problems clearly and be self-healing whenever possible
2. The method used here does not use docker "host" network for multiple reasons
    - Many academic networks whitelist computers and explicitly disallow bridging to VMs
    - XQuartz listens globally and many tutorials around the internet recommend doing `xhost +` which essentially leaves the X11 server fully open, which is a moderate security risk
    - When a BORIS webUI is introduced we can avoid accidental exposure in the local network
    - It's overall a good security practice to not expose systems if not needed :)
3.  X11 session is authenticated using magic cookies
    - The container's IP isn't known until the container is started, which creates a chicken-egg problem with X11 authorization
    - Relying on hostname (effectively IP) isn't a foolproof method as it may change when user changes networks
    - The `XAUTHORITY` is a preferred method for X11 and is stable until XQuartz/X11 server is restarted, which is a non-issue as BORIS will be terminated with the X11 server
5. Docker on macOS has some peculiarities
    - Unix sockets (used as a default method in X11) sharing isn't supported on non-Linux hosts (https://github.com/docker/for-mac/issues/483#issuecomment-758836836)
    - There are many tutorials regarding X11 on macOS (e.g. https://gist.github.com/cschiewek/246a244ba23da8b9f0e7b11a68bf3285) but they often sidestep Docker recommendations rather than following them, leading them to break after updates
    - While the performance of volumes on macOS is still lacking ([despite Docker efforts](https://www.docker.com/blog/speed-boost-achievement-unlocked-on-docker-desktop-4-6-for-mac/)), the script is using volume mount for user's home directory to decrease chance of BORIS data and configuration accidental deletion


### WDYT?
Please let me know if this can be merged, or if you would like to suggest some changes. One of our researchers is already using it with great success.