### PR TITLE
Gestures with the mouse to zoom/pan in clicked coords 

### DIFF
--- a/boris/observation_operations.py
+++ b/boris/observation_operations.py
@@ -1400,8 +1400,54 @@ def initialize_new_media_observation(self) -> bool:
 
             @p0.player.on_key_press("MBTN_RIGHT")
             def mbtn_right():
-                # no zoom
                 self.video_click_signal.emit(0, "MBTN_RIGHT")
+            
+            @p0.player.on_key_press("MBTN_LEFT_DBL")
+            def mbtn_left_dbl():
+                self.video_click_signal.emit(0, "MBTN_LEFT_DBL")
+
+            @p0.player.on_key_press("MBTN_RIGHT_DBL")
+            def mbtn_right_dbl():
+                self.video_click_signal.emit(0, "MBTN_RIGHT_DBL")
+            
+            @p0.player.on_key_press("Ctrl+WHEEL_UP")
+            def ctrl_wheel_up():
+                self.video_click_signal.emit(0, "Ctrl+WHEEL_UP")
+
+            @p0.player.on_key_press("Ctrl+WHEEL_DOWN")
+            def ctrl_wheel_down():
+                self.video_click_signal.emit(0, "Ctrl+WHEEL_DOWN")
+            
+            @p0.player.on_key_press("WHEEL_UP")
+            def wheel_up():
+                self.video_click_signal.emit(0, "WHEEL_UP")
+
+            @p0.player.on_key_press("WHEEL_DOWN")
+            def wheel_down():
+                self.video_click_signal.emit(0, "WHEEL_DOWN")
+
+            @p0.player.on_key_press("Shift+WHEEL_UP")
+            def shift_wheel_up():
+                self.video_click_signal.emit(0, "Shift+WHEEL_UP")
+
+            @p0.player.on_key_press("Shift+WHEEL_DOWN")
+            def shift_wheel_down():
+                self.video_click_signal.emit(0, "Shift+WHEEL_DOWN")
+
+            @p0.player.on_key_press("Shift+MBTN_LEFT")
+            def shift_mbtn_left():
+                self.video_click_signal.emit(0, "Shift+MBTN_LEFT")
+
+            
+            # @p0.player.on_key_press("Shift+MOUSE_MOVE")
+            # def shift_mouse_move():
+            #     # no zoom
+            #     self.video_click_signal.emit(0, "Shift+MOUSE_MOVE")
+            # @p0.player.on_key_press("MOUSE_MOVE")
+            # def mouse_move():
+            #     # no zoom
+            #     self.video_click_signal.emit(0, "MOUSE_MOVE")
+            
 
             self.dw_player.append(p0)
 


### PR DESCRIPTION
Hi,
This code implements a possible set of gestures for zoom and pan.
Files changed:
- observation_operations.py
Some signals were added only to the first player
- core.py
added zoom and pan gestures with the mouse wheel  
defined some functions to simplify code

**Gestures**
if cmd == "MBTN_LEFT_DBL":
   ZOOM IN x2         
if cmd == "MBTN_RIGHT_DBL":
   ZOOM OUT x2
if cmd == "Ctrl+WHEEL_UP":
   ZOOM IN (3 wheel steps to zoom X2)            
if cmd == "Ctrl+WHEEL_DOWN":
   ZOOM OUT (3 wheel steps to zoom X2)
if cmd == "WHEEL_UP": 
   PAN UP (VIDEO MOVES DOWN)
if cmd == "WHEEL_DOWN": 
   PAN DOWN (VIDEO MOVES UP)
if cmd == "Shift+WHEEL_UP": 
   PAN LEFT (VIDEO MOVES TO THE RIGHT)
if cmd == "Shift+WHEEL_DOWN": 
   PAN RIGHT (VIDEO MOVES TO THE LEFT)
if cmd == "Shift+MBTN_LEFT":            
   RESET PAN AND ZOOM TO DEFAULT
