### PR TITLE
cut off media durations to only 3 decimal places

### DIFF
--- a/boris/observation_operations.py
+++ b/boris/observation_operations.py
@@ -19,7 +19,7 @@ Copyright 2012-2025 Olivier Friard
   MA 02110-1301, USA.
 """
 
-from math import log2
+from math import log2, floor
 import os
 import logging
 import time
@@ -2405,12 +2405,14 @@ def event2media_file_name(observation: dict, timestamp: dec) -> Optional[str]:
         str: name of media file containing the event
     """
 
-    cumul_media_durations: list = [dec(0)]
+    cumul_media_durations: list = [float(0)]
     for media_file in observation[cfg.FILE]["1"]:
-        media_duration = dec(str(observation[cfg.MEDIA_INFO][cfg.LENGTH][media_file]))
-        cumul_media_durations.append(cumul_media_durations[-1] + media_duration)
+        media_duration = float(str(observation[cfg.MEDIA_INFO][cfg.LENGTH][media_file]))
+        # cut off media duration to 3 decimal places as that is how fine the player is
+        media_duration = float(floor(media_duration * 10**3) / 10**3)
+        cumul_media_durations.append(floor((cumul_media_durations[-1] + media_duration) * 10**3) / 10**3)
 
-    cumul_media_durations.remove(dec(0))
+    cumul_media_durations.remove(float(0))
 
     # test if timestamp is at end of last media
     if timestamp == cumul_media_durations[-1]:
@@ -2419,7 +2421,7 @@ def event2media_file_name(observation: dict, timestamp: dec) -> Optional[str]:
         player_idx = -1
         for idx, value in enumerate(cumul_media_durations):
             start = 0 if idx == 0 else cumul_media_durations[idx - 1]
-            if start <= timestamp < value:
+            if start <= float(timestamp) < value:
                 player_idx = idx
                 break
 


### PR DESCRIPTION
dropped decimals for floats in event2media_file_name()

Hey Oliver,

I’m making this pull request to address [issue 854](https://github.com/olivierfriard/BORIS/issues/854). I’m a very rusty Python coder and don’t have any experience working with the decimal package, so it’s very likely that there is a more elegant way to fix this issue, but I wanted to create this pull request anyways to help explain the cause of the issue so you can make a better fix if needed. 

**Cause of Issue**: The short story of the issue is that the media duration taken from the observation dictionary is technically longer than the first possible timestamp you can export for the subsequently played media file. I’ll explain further with an example from my media files. Say media file 1 shows a duration of 17.199 in the BORIS player/GUI and I save a point event at frame 0 of media file 2, so the timestamp for the event would be 17.199. Behind the scenes however, event2media_file_name() will show the duration of media file 1 as 17.1990000234 (line 2410). Therefore, when evaluating if the timestamp of the event occurred between the start and end of media file 1 (line 2422), 17.199 is less than 17.1990000234 and it assigns media file name as media file 1 even though the BORIS player shows timestamp 17.199 as after the end of media file 1 and should be counted as the first frame of media file 2. I messed with this a little bit and I believe this is due to the decimal package, but as I said I don’t have much experience with this package. 

**My proposed solution**: To fix this, my solution was to cut off the media duration object to 3 decimal places to match the precision used in the player and in the timestamp object. This way the media duration is not longer than the first timestamp of the next subsequent media file.

I think these observations match what I was seeing in [issue 854](https://github.com/olivierfriard/BORIS/issues/854) as frame 0 for every media file was assigned to the previous file. And in my use case where I had over 100 video files, it would make sense sense that frames 1 and 2 of some files would be affected because the duration of the media files are added together (line 2411) and the start times of a media file are getting shifted further back as you have more files. I only tested with my own video files which are all 30fps .AVI files, so there may be more to consider for my proposed solution, but I still wanted to share my findings to help you come up with a solution that works in more use cases. 

Thank you!