### PR TITLE
Add codespell support with configuration and typo fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/boris/advanced_event_filtering.py
+++ b/boris/advanced_event_filtering.py
@@ -78,7 +78,7 @@ class Advanced_event_filtering_dialog(QDialog):
 
     summary_header: tuple = (
         "Observation id",
-        "Number of occurences",
+        "Number of occurrences",
         "Total duration (s)",
         "Duration mean (s)",
         "Std Dev",
@@ -185,7 +185,7 @@ class Advanced_event_filtering_dialog(QDialog):
 
     def add_logic(self):
         """
-        add selected logic operaton to lineedit
+        add selected logic operation to lineedit
         """
         if self.lw3.currentItem():
             text = ""

--- a/boris/analysis_plugins/list_of_dataframe_columns.py
+++ b/boris/analysis_plugins/list_of_dataframe_columns.py
@@ -1,7 +1,7 @@
 """
 BORIS plugin
 
-number of occurences of behaviors
+number of occurrences of behaviors
 """
 
 import pandas as pd

--- a/boris/analysis_plugins/number_of_occurences.py
+++ b/boris/analysis_plugins/number_of_occurences.py
@@ -1,14 +1,14 @@
 """
 BORIS plugin
 
-number of occurences of behaviors
+number of occurrences of behaviors
 """
 
 import pandas as pd
 
 __version__ = "0.3.0"
 __version_date__ = "2025-03-17"
-__plugin_name__ = "Number of occurences of behaviors"
+__plugin_name__ = "Number of occurrences of behaviors"
 __author__ = "Olivier Friard - University of Torino - Italy"
 
 
@@ -17,6 +17,6 @@ def run(df: pd.DataFrame):
     Calculate the number of occurrences of behaviors by subject.
     """
 
-    df_results: pd.DataFrame = df.groupby(["Subject", "Behavior"])["Behavior"].count().reset_index(name="number of occurences")
+    df_results: pd.DataFrame = df.groupby(["Subject", "Behavior"])["Behavior"].count().reset_index(name="number of occurrences")
 
     return df_results

--- a/boris/analysis_plugins/number_of_occurences_by_independent_variable.py
+++ b/boris/analysis_plugins/number_of_occurences_by_independent_variable.py
@@ -1,14 +1,14 @@
 """
 BORIS plugin
 
-number of occurences of behaviors by independent_variable
+number of occurrences of behaviors by independent_variable
 """
 
 import pandas as pd
 
 __version__ = "0.4.0"
 __version_date__ = "2025-07-17"
-__plugin_name__ = "Number of occurences of behaviors by subject by independent_variable"
+__plugin_name__ = "Number of occurrences of behaviors by subject by independent_variable"
 __author__ = "Olivier Friard - University of Torino - Italy"
 
 
@@ -37,7 +37,7 @@ def run(df: pd.DataFrame):
                 ]
             )["Behavior"]
             .count()
-            .reset_index(name="number of occurences")
+            .reset_index(name="number of occurrences")
         )
 
         grouped_df.rename(columns={column: "Value"}, inplace=True)

--- a/boris/analysis_plugins/time_budget.py
+++ b/boris/analysis_plugins/time_budget.py
@@ -17,7 +17,7 @@ def run(df: pd.DataFrame):
     """
     Calculate the following values:
 
-    - Total number of occurences of behavior
+    - Total number of occurrences of behavior
     - Total duration of behavior (in seconds)  (pandas.DataFrame.sum() ignore NaN values when computing the sum. Use min_count=1)
     - Duration mean of behavior (in seconds)
     - Standard deviation of behavior duration (in seconds)
@@ -29,7 +29,7 @@ def run(df: pd.DataFrame):
     group_by = ["Subject", "Behavior"]
 
     dfs = [
-        df.groupby(group_by)["Behavior"].count().reset_index(name="number of occurences"),
+        df.groupby(group_by)["Behavior"].count().reset_index(name="number of occurrences"),
         df.groupby(group_by)["Duration (s)"].sum(min_count=1).reset_index(name="total duration"),
         df.groupby(group_by)["Duration (s)"].mean().astype(float).round(3).reset_index(name="duration mean"),
         df.groupby(group_by)["Duration (s)"].std().astype(float).round(3).reset_index(name="duration std dev"),

--- a/boris/boris_cli.py
+++ b/boris/boris_cli.py
@@ -73,13 +73,13 @@ commands_usage = {
         "usage:\nboris_cli -p PROJECT_FILE -o OBSERVATION_ID --command check_state_events\n"
         "where\n"
         "PROJECT_FILE is the path of the BORIS project\n"
-        "OBSERVATION_ID is the id of observation(s) (if ommitted all observations are checked)"
+        "OBSERVATION_ID is the id of observation(s) (if omitted all observations are checked)"
     ),
     "export_events": (
         "usage:\nboris_cli -p PROJECT_FILE -o OBSERVATION_ID --command export_events [OUTPUT_FORMAT]\n"
         "where:\n"
         "PROJECT_FILE is the path of the BORIS project\n"
-        "OBSERVATION_ID is the id of observation(s) (if ommitted all observations are exported)\n"
+        "OBSERVATION_ID is the id of observation(s) (if omitted all observations are exported)\n"
         "OUTPUT_FORMAT can be tsv (default), csv, xls, xlsx, ods, html"
     ),
     "irr": (
@@ -304,7 +304,7 @@ def main(argv=None):
             if msg:
                 print(cleanhtml(msg))
             else:
-                print("No issuses found in project")
+                print("No issues found in project")
             sys.exit()
 
         if "plot_events" in args.command[0]:

--- a/boris/config_file.py
+++ b/boris/config_file.py
@@ -112,7 +112,7 @@ def read(self) -> None:
         except Exception:
             self.automaticBackup = 0
 
-        # activate or desactivate autosave timer
+        # activate or deactivate autosave timer
         if self.automaticBackup:
             self.automaticBackupTimer.start(self.automaticBackup * 60000)
         else:

--- a/boris/converters.py
+++ b/boris/converters.py
@@ -81,7 +81,7 @@ def add_converter(self):
 
 def modify_converter(self):
     """
-    Modifiy the selected converter
+    Modify the selected converter
     """
 
     if not self.tw_converters.selectedIndexes():
@@ -252,13 +252,13 @@ def load_converters_from_file_repo(self, mode: str):
         try:
             converters_from_repo = urllib.request.urlopen(converters_repo_URL).read().strip().decode("utf-8")
         except Exception:
-            QMessageBox.critical(self, cfg.programName, "An error occured during retrieving converters from BORIS remote repository")
+            QMessageBox.critical(self, cfg.programName, "An error occurred during retrieving converters from BORIS remote repository")
             return
 
         try:
             converters_from_file = eval(converters_from_repo)["BORIS converters"]
         except Exception:
-            QMessageBox.critical(self, cfg.programName, "An error occured during retrieving converters from BORIS remote repository")
+            QMessageBox.critical(self, cfg.programName, "An error occurred during retrieving converters from BORIS remote repository")
             return
 
     if converters_from_file:

--- a/boris/core.py
+++ b/boris/core.py
@@ -2906,7 +2906,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                                             + value.split(")")[-1]
                                         )
                             except Exception:
-                                logging.warning("error during convertion of modifier short cut to lower case")
+                                logging.warning("error during conversion of modifier short cut to lower case")
 
                     for idx in pj[cfg.SUBJECTS]:
                         pj[cfg.SUBJECTS][idx][cfg.SUBJECT_KEY] = pj[cfg.SUBJECTS][idx][cfg.SUBJECT_KEY].lower()
@@ -3227,7 +3227,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     (
                         "Please note that editing the project may interfere with the coded events in your previous observations.<br>"
                         "For example modifying a behavior code, renaming a subject or modifying the modifiers sets "
-                        "can unvalidate your previous observations.<br>"
+                        "can invalidate your previous observations.<br>"
                         "Remember to make a backup of your project."
                     ),
                     (cfg.CANCEL, "Edit"),
@@ -4640,7 +4640,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def getLaps(self, n_player: int = 0) -> dec:
         """
-        Cumulative laps time from begining of observation
+        Cumulative laps time from beginning of observation
         do not add time offset
 
         Args:
@@ -4673,7 +4673,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     and util.extract_exif_DateTimeOriginal(self.images_list[self.image_idx]) != -1
                 ):
                     time_ = util.extract_exif_DateTimeOriginal(self.images_list[self.image_idx])
-                    # check if first value must be substracted
+                    # check if first value must be subtracted
                     if self.pj[cfg.OBSERVATIONS][self.observationId].get(cfg.SUBSTRACT_FIRST_EXIF_DATE, True):
                         time_ -= self.image_time_ref
 
@@ -4698,7 +4698,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def get_obs_time(self, n_player: int = 0) -> tuple[dec, dec | None]:
         """
-        returns time in current media and cumulative time from begining of observation
+        returns time in current media and cumulative time from beginning of observation
         do not add time offset
 
         Args:
@@ -5275,10 +5275,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
             time_ = util.time2seconds(time_str) if ":" in time_str else dec(time_str)
 
-            # substract time offset
+            # subtract time offset
             time_ -= self.pj[cfg.OBSERVATIONS][self.observationId][cfg.TIME_OFFSET]
 
-            # substract media creation time
+            # subtract media creation time
             if self.pj[cfg.OBSERVATIONS][self.observationId].get(cfg.MEDIA_CREATION_DATE_AS_OFFSET, False):
                 if len(self.dw_player[0].player.playlist) > 1:
                     QMessageBox.information(

--- a/boris/db_functions.py
+++ b/boris/db_functions.py
@@ -77,7 +77,7 @@ def load_events_in_db(
             "code TEXT, "
             "type TEXT, "
             "modifiers TEXT, "
-            "occurence FLOAT, "
+            "occurrence FLOAT, "
             "comment TEXT,"
             "image_index INTEGER,"
             "image_path TEXT)"
@@ -101,7 +101,7 @@ def load_events_in_db(
                             cursor.execute(
                                 (
                                     "INSERT INTO events "
-                                    "(observation, subject, code, type, modifiers, occurence, comment, image_index) "
+                                    "(observation, subject, code, type, modifiers, occurrence, comment, image_index) "
                                     "VALUES (?,?,?,?,?,?,?,?)"
                                 ),
                                 (
@@ -123,7 +123,7 @@ def load_events_in_db(
                             cursor.execute(
                                 (
                                     "INSERT INTO events "
-                                    "(observation, subject, code, type, modifiers, occurence, comment, image_index, image_path) "
+                                    "(observation, subject, code, type, modifiers, occurrence, comment, image_index, image_path) "
                                     "VALUES (?,?,?,?,?,?,?,?,?)"
                                 ),
                                 (
@@ -264,8 +264,8 @@ def load_aggregated_events_in_db(
                 for distinct_modifiers in rows_distinct_modifiers:
                     cursor1.execute(
                         (
-                            "SELECT occurence, comment, image_index, image_path FROM events "
-                            "WHERE subject = ? AND code = ? AND modifiers = ? ORDER by occurence"
+                            "SELECT occurrence, comment, image_index, image_path FROM events "
+                            "WHERE subject = ? AND code = ? AND modifiers = ? ORDER by occurrence"
                         ),
                         (subject, behavior, distinct_modifiers),
                     )
@@ -279,8 +279,8 @@ def load_aggregated_events_in_db(
                                 behavior,
                                 cfg.POINT,
                                 distinct_modifiers,
-                                row["occurence"],
-                                row["occurence"],
+                                row["occurrence"],
+                                row["occurrence"],
                                 row["comment"],
                                 "",  # no stop comment for point event
                                 row["image_index"],
@@ -298,8 +298,8 @@ def load_aggregated_events_in_db(
                                     behavior,
                                     cfg.STATE,
                                     distinct_modifiers,
-                                    row["occurence"],
-                                    rows[idx + 1]["occurence"],
+                                    row["occurrence"],
+                                    rows[idx + 1]["occurrence"],
                                     row["comment"],
                                     rows[idx + 1]["comment"],
                                     row["image_index"],

--- a/boris/dialog.py
+++ b/boris/dialog.py
@@ -98,7 +98,7 @@ def global_error_message(exception_type, exception_value, traceback_object):
 
     error_text = "\n\nSystem info\n===========\n\n"
     error_text += util.get_systeminfo()
-    error_text += f"Error succeded at {dt.datetime.now():%Y-%m-%d %H:%M}\n\n"
+    error_text += f"Error succeeded at {dt.datetime.now():%Y-%m-%d %H:%M}\n\n"
     error_text += "".join(traceback.format_exception(exception_type, exception_value, traceback_object))
 
     # write to stdout
@@ -117,7 +117,7 @@ def global_error_message(exception_type, exception_value, traceback_object):
     cb.setText(error_text)
 
     text: str = (
-        f"An error has occured!\n\n"
+        f"An error has occurred!\n\n"
         "to improve the software please report this problem at:\n"
         "https://github.com/olivierfriard/BORIS/issues\n\n"
         "Please no screenshot, the error message was copied to the clipboard.\n\n"
@@ -127,7 +127,7 @@ def global_error_message(exception_type, exception_value, traceback_object):
 
     errorbox = Results_dialog()
 
-    errorbox.setWindowTitle("BORIS - An error occured")
+    errorbox.setWindowTitle("BORIS - An error occurred")
     errorbox.pbOK.setText(cfg.ABORT)
     errorbox.pbCancel.setVisible(True)
     errorbox.pbCancel.setText("Ignore and try to continue")

--- a/boris/dialog.py
+++ b/boris/dialog.py
@@ -93,7 +93,7 @@ def MessageDialog(title: str, text: str, buttons: tuple) -> str:
 def global_error_message(exception_type, exception_value, traceback_object):
     """
     Global error management
-    save error using loggin.critical and stdout
+    save error using logging.critical and stdout
     """
 
     error_text = "\n\nSystem info\n===========\n\n"

--- a/boris/event_operations.py
+++ b/boris/event_operations.py
@@ -170,7 +170,7 @@ def add_event(self):
                             if exif_date_time != -1:
                                 time_ = exif_date_time
 
-                                # check if first value must be substracted
+                                # check if first value must be subtracted
                                 if self.pj[cfg.OBSERVATIONS][self.observationId].get(cfg.SUBSTRACT_FIRST_EXIF_DATE, True):
                                     time_ -= self.image_time_ref
 
@@ -860,7 +860,7 @@ def edit_time_selected_events(self):
 
     w = dialog.Ask_time(0)
     w.setWindowTitle("Shift time of selected event(s)")
-    w.label.setText("Amount of time to add or substract")
+    w.label.setText("Amount of time to add or subtract")
 
     if not w.exec_():
         return

--- a/boris/events_snapshots.py
+++ b/boris/events_snapshots.py
@@ -146,18 +146,18 @@ def extract_media_snapshots(self):
             for subject in parameters[cfg.SELECTED_SUBJECTS]:
                 for behavior in parameters[cfg.SELECTED_BEHAVIORS]:
                     cursor.execute(
-                        "SELECT occurence, modifiers FROM events WHERE observation = ? AND subject = ? AND code = ?",
+                        "SELECT occurrence, modifiers FROM events WHERE observation = ? AND subject = ? AND code = ?",
                         (obs_id, subject, behavior),
                     )
 
                     rows = tuple(
-                        {"occurence": util.float2decimal(r["occurence"]), "modifiers": r[cfg.MODIFIERS]} for r in cursor.fetchall()
+                        {"occurrence": util.float2decimal(r["occurrence"]), "modifiers": r[cfg.MODIFIERS]} for r in cursor.fetchall()
                     )
 
                     behavior_state = project_functions.event_type(behavior, self.pj[cfg.ETHOGRAM])
 
                     for idx, row in enumerate(rows):
-                        mediaFileIdx = [idx1 for idx1, x in enumerate(duration1) if row["occurence"] >= sum(duration1[0:idx1])][-1]
+                        mediaFileIdx = [idx1 for idx1, x in enumerate(duration1) if row["occurrence"] >= sum(duration1[0:idx1])][-1]
 
                         # check if media has video
                         flag_no_video = False
@@ -213,9 +213,9 @@ def extract_media_snapshots(self):
                             if response == cfg.ABORT:
                                 return
 
-                        global_start = dec("0.000") if row["occurence"] < time_interval else round(row["occurence"] - time_interval, 3)
+                        global_start = dec("0.000") if row["occurrence"] < time_interval else round(row["occurrence"] - time_interval, 3)
                         start = round(
-                            row["occurence"]
+                            row["occurrence"]
                             - time_interval
                             - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                             - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],
@@ -239,7 +239,7 @@ def extract_media_snapshots(self):
                                 # check if stop is on same media file
                                 if (
                                     mediaFileIdx
-                                    != [idx1 for idx1, x in enumerate(duration1) if rows[idx + 1]["occurence"] >= sum(duration1[0:idx1])][
+                                    != [idx1 for idx1, x in enumerate(duration1) if rows[idx + 1]["occurrence"] >= sum(duration1[0:idx1])][
                                         -1
                                     ]
                                 ):
@@ -257,10 +257,10 @@ def extract_media_snapshots(self):
                                     if response == cfg.ABORT:
                                         return
 
-                                # globalStop = round(rows[idx + 1]["occurence"] + time_interval, 3)
+                                # globalStop = round(rows[idx + 1]["occurrence"] + time_interval, 3)
 
                                 stop = round(
-                                    rows[idx + 1]["occurence"]
+                                    rows[idx + 1]["occurrence"]
                                     + time_interval
                                     - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                                     - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],
@@ -448,18 +448,18 @@ def extract_media_clips(self):
             for subject in parameters[cfg.SELECTED_SUBJECTS]:
                 for behavior in parameters[cfg.SELECTED_BEHAVIORS]:
                     cursor.execute(
-                        "SELECT occurence, modifiers FROM events WHERE observation = ? AND subject = ? AND code = ?",
+                        "SELECT occurrence, modifiers FROM events WHERE observation = ? AND subject = ? AND code = ?",
                         (obs_id, subject, behavior),
                     )
                     rows = tuple(
-                        {"occurence": util.float2decimal(r["occurence"]), "modifiers": r[cfg.MODIFIERS]} for r in cursor.fetchall()
+                        {"occurrence": util.float2decimal(r["occurrence"]), "modifiers": r[cfg.MODIFIERS]} for r in cursor.fetchall()
                     )
                     behavior_state = project_functions.event_type(behavior, self.pj[cfg.ETHOGRAM])
                     if behavior_state in cfg.STATE_EVENT_TYPES and len(rows) % 2:  # unpaired events
                         continue
 
                     for idx, row in enumerate(rows):
-                        mediaFileIdx = [idx1 for idx1, x in enumerate(duration1) if row["occurence"] >= sum(duration1[0:idx1])][-1]
+                        mediaFileIdx = [idx1 for idx1, x in enumerate(duration1) if row["occurrence"] >= sum(duration1[0:idx1])][-1]
 
                         if "VIDEO" in items_to_extract.upper():
                             # check if media has video
@@ -515,9 +515,9 @@ def extract_media_clips(self):
                             codecs = "-vn"
 
                         if behavior_state in cfg.POINT_EVENT_TYPES:
-                            globalStart = dec("0.000") if row["occurence"] < timeOffset else round(row["occurence"] - timeOffset, 3)
+                            globalStart = dec("0.000") if row["occurrence"] < timeOffset else round(row["occurrence"] - timeOffset, 3)
                             start = round(
-                                row["occurence"]
+                                row["occurrence"]
                                 - (timeOffset if timeOffset else 1)  # if time offset is not set default = 1 s
                                 - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                                 - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],
@@ -526,10 +526,10 @@ def extract_media_clips(self):
                             if start < timeOffset:
                                 start = dec("0.000")
 
-                            globalStop = round(row["occurence"] + timeOffset, 3)
+                            globalStop = round(row["occurrence"] + timeOffset, 3)
 
                             stop = round(
-                                row["occurence"]
+                                row["occurrence"]
                                 + (timeOffset if timeOffset else 1)  # if time offset is not set default = 1 s
                                 - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                                 - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],
@@ -541,7 +541,7 @@ def extract_media_clips(self):
                                 # check if stop is on same media file
                                 if (
                                     mediaFileIdx
-                                    != [idx1 for idx1, x in enumerate(duration1) if rows[idx + 1]["occurence"] >= sum(duration1[0:idx1])][
+                                    != [idx1 for idx1, x in enumerate(duration1) if rows[idx + 1]["occurrence"] >= sum(duration1[0:idx1])][
                                         -1
                                     ]
                                 ):
@@ -558,9 +558,9 @@ def extract_media_clips(self):
                                     if response == cfg.ABORT:
                                         return
 
-                                globalStart = dec("0.000") if row["occurence"] < timeOffset else round(row["occurence"] - timeOffset, 3)
+                                globalStart = dec("0.000") if row["occurrence"] < timeOffset else round(row["occurrence"] - timeOffset, 3)
                                 start = round(
-                                    row["occurence"]
+                                    row["occurrence"]
                                     - timeOffset
                                     - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                                     - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],
@@ -569,10 +569,10 @@ def extract_media_clips(self):
                                 if start < timeOffset:
                                     start = dec("0.000")
 
-                                globalStop = round(rows[idx + 1]["occurence"] + timeOffset, 3)
+                                globalStop = round(rows[idx + 1]["occurrence"] + timeOffset, 3)
 
                                 stop = round(
-                                    rows[idx + 1]["occurence"]
+                                    rows[idx + 1]["occurrence"]
                                     + timeOffset
                                     - util.float2decimal(sum(duration1[0:mediaFileIdx]))
                                     - self.pj[cfg.OBSERVATIONS][obs_id][cfg.TIME_OFFSET],

--- a/boris/export_observation.py
+++ b/boris/export_observation.py
@@ -929,7 +929,7 @@ def events_to_behavioral_sequences(pj, obs_id: str, subj: str, parameters: dict,
         obs_id (str): observation id
         subj (str): subject
         parameters (dict): parameters
-        behav_seq_separator (str): separator of behviors in behavioral sequences
+        behav_seq_separator (str): separator of behaviors in behavioral sequences
 
     Returns:
         str: behavioral string for selected subject in selected observation
@@ -1012,7 +1012,7 @@ def events_to_behavioral_sequences_all_subj(pj, obs_id: str, subjects_list: list
         obs_id (str): observation id
         subjects_list (list): list of subjects
         parameters (dict): parameters
-        behav_seq_separator (str): separator of behviors in behavioral sequences
+        behav_seq_separator (str): separator of behaviors in behavioral sequences
 
     Returns:
         str: behavioral sequences for all selected subjects in selected observation
@@ -1097,7 +1097,7 @@ def events_to_timed_behavioral_sequences(
         subj (str): subject
         parameters (dict): parameters
         precision (float): time value for scan sample
-        behav_seq_separator (str): separator of behviors in behavioral sequences
+        behav_seq_separator (str): separator of behaviors in behavioral sequences
 
     Returns:
         str: behavioral string for selected subject in selected observation

--- a/boris/geometric_measurement.py
+++ b/boris/geometric_measurement.py
@@ -390,7 +390,7 @@ class wgMeasurement(QDialog):
                 pyreadr.write_rds(file_name, df)
 
         except Exception:
-            QMessageBox.warning(self, cfg.programName, "An error occured during saving the measurement results")
+            QMessageBox.warning(self, cfg.programName, "An error occurred during saving the measurement results")
             return True
         return False  # everything OK
 

--- a/boris/import_observations.py
+++ b/boris/import_observations.py
@@ -73,10 +73,10 @@ def load_observations_from_boris_project(self, project_file_path: str):
     if selected_observations:
         flagImported = False
 
-        # set of behaviors in current projet ethogram
+        # set of behaviors in current project ethogram
         behav_set = set([self.pj[cfg.ETHOGRAM][idx][cfg.BEHAVIOR_CODE] for idx in self.pj[cfg.ETHOGRAM]])
 
-        # set of subjects in current projet
+        # set of subjects in current project
         subjects_set = set([self.pj[cfg.SUBJECTS][idx][cfg.SUBJECT_NAME] for idx in self.pj[cfg.SUBJECTS]])
 
         for obs_id in selected_observations:

--- a/boris/observation.py
+++ b/boris/observation.py
@@ -143,7 +143,7 @@ class Observation(QDialog, Ui_Form):
             {
                 "from directory": [
                     "dir abs path|with absolute path ",
-                    "dir rel path|wih relative path ",
+                    "dir rel path|with relative path ",
                 ]
             },
         ]
@@ -165,7 +165,7 @@ class Observation(QDialog, Ui_Form):
         self.action1.triggered.connect(lambda: self.add_media(mode="media abs path|with absolute path"))
         self.action2.triggered.connect(lambda: self.add_media(mode="media rel path|with relative path"))
         self.action3.triggered.connect(lambda: self.add_media(mode="dir abs path|with absolute path"))
-        self.action4.triggered.connect(lambda: self.add_media(mode="dir rel path|wih relative path"))
+        self.action4.triggered.connect(lambda: self.add_media(mode="dir rel path|with relative path"))
         """
 
         self.media_menu.triggered.connect(lambda x: self.add_media(mode=x.statusTip()))
@@ -258,7 +258,7 @@ class Observation(QDialog, Ui_Form):
 
     # def cb_date_offset_changed(self):
     #    """
-    #    activate/desactivate time value
+    #    activate/deactivate time value
     #    """
     #    self.de_date_offset.setEnabled(self.cb_date_offset.isChecked())
 
@@ -306,7 +306,7 @@ class Observation(QDialog, Ui_Form):
 
     def cb_time_offset_changed(self):
         """
-        activate/desactivate date value
+        activate/deactivate date value
         """
         self.obs_time_offset.setEnabled(self.cb_time_offset.isChecked())
 
@@ -753,7 +753,7 @@ class Observation(QDialog, Ui_Form):
                 item.setBackground(self.not_editable_column_color())
             self.tw_data_files.setItem(self.tw_data_files.rowCount() - 1, col_idx, item)
 
-        # substract first value
+        # subtract first value
         combobox = QComboBox()
         combobox.addItems(["True", "False"])
         self.tw_data_files.setCellWidget(self.tw_data_files.rowCount() - 1, cfg.PLOT_DATA_SUBSTRACT1STVALUE_IDX, combobox)
@@ -1105,12 +1105,12 @@ class Observation(QDialog, Ui_Form):
                     )
                     return False
 
-            # check that the longuest media is in player #1
+            # check that the longest media is in player #1
             durations: list = []
             for i in sorted(list(players.keys())):
                 durations.append(sum(players[i]))
             if [x for x in durations[1:] if x > durations[0]]:
-                QMessageBox.critical(self, cfg.programName, "The longuest media file(s) must be loaded in player #1")
+                QMessageBox.critical(self, cfg.programName, "The longest media file(s) must be loaded in player #1")
                 return False
 
             # check offset for media files

--- a/boris/observation.ui
+++ b/boris/observation.ui
@@ -505,7 +505,7 @@
                  </column>
                  <column>
                   <property name="text">
-                   <string>Substract first value</string>
+                   <string>Subtract first value</string>
                   </property>
                  </column>
                  <column>

--- a/boris/observation_operations.py
+++ b/boris/observation_operations.py
@@ -722,7 +722,7 @@ def new_observation(self, mode: str = cfg.NEW, obsId: str = "") -> None:
         mode (str): NEW or EDIT
         obsId (str): observation Id to be edited
 
-    Retruns:
+    Returns:
         None
 
     """
@@ -1189,12 +1189,12 @@ def new_observation(self, mode: str = cfg.NEW, obsId: str = "") -> None:
             # check if exif data must be used
             self.pj[cfg.OBSERVATIONS][new_obs_id][cfg.USE_EXIF_DATE] = observationWindow.rb_use_exif.isChecked()
 
-            # ask if the value of the exif date time of the first picture must be substracted
+            # ask if the value of the exif date time of the first picture must be subtracted
             # TODO: improve this
             if self.pj[cfg.OBSERVATIONS][new_obs_id][cfg.USE_EXIF_DATE]:
                 response = dialog.MessageDialog(
                     cfg.programName,
-                    "You choose to use the EXIF metadata. Do you want to substract the date time value of the first picture?",
+                    "You choose to use the EXIF metadata. Do you want to subtract the date time value of the first picture?",
                     (cfg.YES, cfg.NO),
                 )
                 self.pj[cfg.OBSERVATIONS][new_obs_id][cfg.SUBSTRACT_FIRST_EXIF_DATE] = response == cfg.YES

--- a/boris/player_dock_widget.py
+++ b/boris/player_dock_widget.py
@@ -49,7 +49,7 @@ from PySide6.QtGui import QIcon, QAction
 
 class Clickable_label(QLabel):
     """
-    QLabel class for visualiziong frames for geometric measurments
+    QLabel class for visualiziong frames for geometric measurements
     Label emits a signal when clicked
     """
 

--- a/boris/plot_events.py
+++ b/boris/plot_events.py
@@ -149,7 +149,7 @@ def create_behaviors_bar_plot(
     start_time = param[cfg.START_TIME]
     end_time = param[cfg.END_TIME]
 
-    parameters = ["duration", "number of occurences"]
+    parameters = ["duration", "number of occurrences"]
 
     ok, msg, db_connector = db_functions.load_aggregated_events_in_db(pj, selected_subjects, selected_observations, selected_behaviors)
 
@@ -200,7 +200,7 @@ def create_behaviors_bar_plot(
             axs2[0] = ax2
 
         fig.suptitle("Durations of behaviors")
-        fig2.suptitle("Number of occurences of behaviors")
+        fig2.suptitle("Number of occurrences of behaviors")
 
         # if modifiers not to be included set modifiers to ""
         cursor.execute("UPDATE aggregated_events SET modifiers = ''")
@@ -261,7 +261,7 @@ def create_behaviors_bar_plot(
 
         for ax_idx, subject in enumerate(sorted(distinct_subjects)):
             for behavior in distinct_behav:
-                # number of occurences
+                # number of occurrences
                 cursor.execute(
                     ("SELECT COUNT(*) AS count FROM aggregated_events WHERE observation = ? AND subject = ? AND behavior = ?"),
                     (
@@ -271,7 +271,7 @@ def create_behaviors_bar_plot(
                     ),
                 )
                 for row in cursor.fetchall():
-                    behaviors[subject][behavior]["number of occurences"] = 0 if row["count"] is None else row["count"]
+                    behaviors[subject][behavior]["number of occurrences"] = 0 if row["count"] is None else row["count"]
 
                 # total duration
                 if project_functions.event_type(behavior, pj[cfg.ETHOGRAM]) in cfg.STATE_EVENT_TYPES:
@@ -299,10 +299,10 @@ def create_behaviors_bar_plot(
             ) = ([], [], [], [], [], [])
 
             for behavior in sorted(distinct_behav):
-                if param[cfg.EXCLUDE_BEHAVIORS] and behaviors[subject][behavior]["number of occurences"] == 0:
+                if param[cfg.EXCLUDE_BEHAVIORS] and behaviors[subject][behavior]["number of occurrences"] == 0:
                     continue
 
-                n_occurences.append(behaviors[subject][behavior]["number of occurences"])
+                n_occurences.append(behaviors[subject][behavior]["number of occurrences"])
                 x_labels.append(behavior)
 
                 # color
@@ -358,7 +358,7 @@ def create_behaviors_bar_plot(
             axs[ax_idx].set_xticklabels(x_labels_duration, rotation="vertical", fontsize=8)
 
             if ax_idx == 0:
-                axs2[ax_idx].set_ylabel("Number of occurences")
+                axs2[ax_idx].set_ylabel("Number of occurrences")
             axs2[ax_idx].set_xlabel("Behaviors")
             axs2[ax_idx].set_title(f"{subject}")
 

--- a/boris/portion/dict.py
+++ b/boris/portion/dict.py
@@ -21,7 +21,7 @@ class IntervalDict(MutableMapping):
     subset of values covered by the given interval. If no matching value is
     found, an empty IntervalDict is returned.
     When keys are "single values", its behaviour corresponds to the one of Python
-    built-in dict. When no matching value is found, a KeyError is raised.
+    built-in dict. When no matchin value is found, a KeyError is raised.
 
     Note that this class does not aim to have the best performance, but is
     provided mainly for convenience. Its performance mainly depends on the

--- a/boris/portion/dict.py
+++ b/boris/portion/dict.py
@@ -21,7 +21,7 @@ class IntervalDict(MutableMapping):
     subset of values covered by the given interval. If no matching value is
     found, an empty IntervalDict is returned.
     When keys are "single values", its behaviour corresponds to the one of Python
-    built-in dict. When no matchin value is found, a KeyError is raised.
+    built-in dict. When no matching value is found, a KeyError is raised.
 
     Note that this class does not aim to have the best performance, but is
     provided mainly for convenience. Its performance mainly depends on the

--- a/boris/preferences.py
+++ b/boris/preferences.py
@@ -527,7 +527,7 @@ def preferences(self):
             item.setData(PLUGIN_NAME_ROLE, plugin_name)
             preferencesWindow.lw_personal_plugins.addItem(item)
 
-    # PROJET FILE INDENTATION
+    # PROJECT FILE INDENTATION
     preferencesWindow.combo_project_file_indentation.clear()
     preferencesWindow.combo_project_file_indentation.addItems(cfg.PROJECT_FILE_INDENTATION_COMBO_OPTIONS)
     try:

--- a/boris/project.py
+++ b/boris/project.py
@@ -166,7 +166,7 @@ class BehavioralCategories(QDialog):
                 )
                 == cfg.YES
             ):
-                # add behavioral categories present in ethogram in behavioal categories list
+                # add behavioral categories present in ethogram in behavioral categories list
                 rc = self.lw.rowCount()
                 self.lw.setRowCount(rc + len(behavioral_categories_in_ethogram.difference(set(behavioral_categories))))
                 for idx, category in enumerate(sorted(list(behavioral_categories_in_ethogram.difference(set(behavioral_categories))))):
@@ -1029,7 +1029,7 @@ class projectDialog(QDialog, Ui_dlgProject):
                     f"Row: {r + 1} - The variable label <b>{self.twVariables.item(r, 0).text()}</b> is already in use.",
                 )
 
-            # check if same lables
+            # check if same labels
             existing_var.append(self.twVariables.item(r, 0).text().strip().upper())
 
             # check default value
@@ -1463,7 +1463,7 @@ class projectDialog(QDialog, Ui_dlgProject):
                 try:
                     new_map = json.loads(open(file_name, "r").read())
                 except Exception:
-                    QMessageBox.critical(self, cfg.programName, "Error reding the coding map")
+                    QMessageBox.critical(self, cfg.programName, "Error reading the coding map")
                     return
                 self.pj[cfg.CODING_MAP][new_map["name"]] = new_map
 
@@ -1989,7 +1989,7 @@ class projectDialog(QDialog, Ui_dlgProject):
                         QMessageBox.warning(
                             self,
                             cfg.programName,
-                            f"The label of an indipendent variable can not be empty (check row #{r + 1}).",
+                            f"The label of an independent variable can not be empty (check row #{r + 1}).",
                         )
                         return
 

--- a/boris/project_functions.py
+++ b/boris/project_functions.py
@@ -970,7 +970,7 @@ def set_media_paths_relative_to_project_dir(pj: dict, project_file_name: str) ->
         bool: True if project changed else False
     """
 
-    # chek if media and images dir are relative to project dir
+    # check if media and images dir are relative to project dir
     for obs_id in pj[cfg.OBSERVATIONS]:
         if pj[cfg.OBSERVATIONS][obs_id][cfg.TYPE] == cfg.IMAGES:
             for img_dir in pj[cfg.OBSERVATIONS][obs_id][cfg.DIRECTORIES_LIST]:
@@ -1062,7 +1062,7 @@ def set_data_paths_relative_to_project_dir(pj: dict, project_file_name: str) -> 
     Returns:
         bool: True if project changed else False
     """
-    # chek if data paths are relative to project dir
+    # check if data paths are relative to project dir
     for obs_id in pj[cfg.OBSERVATIONS]:
         for _, v in pj[cfg.OBSERVATIONS][obs_id].get(cfg.PLOT_DATA, {}).items():
             if cfg.FILE_PATH in v:

--- a/boris/project_import_export.py
+++ b/boris/project_import_export.py
@@ -743,13 +743,13 @@ def import_behaviors_from_repository(self):
     try:
         ethogram_list = urllib.request.urlopen(f"{cfg.ETHOGRAM_REPOSITORY_URL}/ethogram_list.json").read().strip().decode("utf-8")
     except Exception:
-        QMessageBox.critical(self, cfg.programName, "An error occured during retrieving the ethogram list from BORIS repository")
+        QMessageBox.critical(self, cfg.programName, "An error occurred during retrieving the ethogram list from BORIS repository")
         return
 
     try:
         ethogram_list_list = json.loads(ethogram_list)
     except Exception:
-        QMessageBox.critical(self, cfg.programName, "An error occured during loading ethogram list from BORIS repository")
+        QMessageBox.critical(self, cfg.programName, "An error occurred during loading ethogram list from BORIS repository")
         return
 
     choice_dialog = dialog.ChooseObservationsToImport(
@@ -777,7 +777,7 @@ def import_behaviors_from_repository(self):
     try:
         boris_project_str = urllib.request.urlopen(f"{cfg.ETHOGRAM_REPOSITORY_URL}/{file_name}").read().strip().decode("utf-8")
     except Exception:
-        QMessageBox.critical(self, cfg.programName, f"An error occured during retrieving {file_name} from BORIS repository")
+        QMessageBox.critical(self, cfg.programName, f"An error occurred during retrieving {file_name} from BORIS repository")
         return
     boris_project = json.loads(boris_project_str)
 

--- a/boris/time_budget_functions.py
+++ b/boris/time_budget_functions.py
@@ -743,11 +743,11 @@ def time_budget_analysis(
                     for modifier in distinct_modifiers:
                         cursor.execute(
                             (
-                                "SELECT occurence, observation FROM events "
+                                "SELECT occurrence, observation FROM events "
                                 "WHERE subject = ? "
                                 "AND code = ? "
                                 "AND modifiers = ? "
-                                "ORDER BY observation, occurence"
+                                "ORDER BY observation, occurrence"
                             ),
                             (subject, behavior, modifier),
                         )
@@ -756,11 +756,11 @@ def time_budget_analysis(
 
                         if len(selected_observations) == 1:
                             new_rows: list = []
-                            for occurence, observation in rows:
-                                if occurence is None:
+                            for occurrence, observation in rows:
+                                if occurrence is None:
                                     new_rows.append([float("NaN"), observation])
                                 else:
-                                    new_rows.append([occurence, observation])
+                                    new_rows.append([occurrence, observation])
                             rows = list(new_rows)
 
                         # include behaviors without events
@@ -815,11 +815,11 @@ def time_budget_analysis(
                     for modifier in distinct_modifiers:
                         cursor.execute(
                             (
-                                "SELECT occurence, observation FROM events "
+                                "SELECT occurrence, observation FROM events "
                                 "WHERE subject = ? "
                                 "AND code = ? "
                                 "AND modifiers = ? "
-                                "ORDER BY observation, occurence"
+                                "ORDER BY observation, occurrence"
                             ),
                             (subject, behavior, modifier),
                         )
@@ -927,7 +927,7 @@ def time_budget_analysis(
             else:  # no modifiers
                 if project_functions.event_type(behavior, ethogram) in cfg.POINT_EVENT_TYPES:
                     cursor.execute(
-                        ("SELECT occurence, observation FROM events WHERE subject = ? AND code = ? ORDER BY observation, occurence"),
+                        ("SELECT occurrence, observation FROM events WHERE subject = ? AND code = ? ORDER BY observation, occurrence"),
                         (subject, behavior),
                     )
 
@@ -935,11 +935,11 @@ def time_budget_analysis(
 
                     if len(selected_observations) == 1:
                         new_rows: list = []
-                        for occurence, observation in rows:
-                            if occurence is None:
+                        for occurrence, observation in rows:
+                            if occurrence is None:
                                 new_rows.append([float("NaN"), observation])
                             else:
-                                new_rows.append([occurence, observation])
+                                new_rows.append([occurrence, observation])
                         rows = list(new_rows)
 
                     # include behaviors without events
@@ -992,7 +992,7 @@ def time_budget_analysis(
 
                 if project_functions.event_type(behavior, ethogram) in cfg.STATE_EVENT_TYPES:
                     cursor.execute(
-                        ("SELECT occurence, observation FROM events WHERE subject = ? AND code = ? ORDER BY observation, occurence"),
+                        ("SELECT occurrence, observation FROM events WHERE subject = ? AND code = ? ORDER BY observation, occurrence"),
                         (subject, behavior),
                     )
 

--- a/boris/time_budget_widget.py
+++ b/boris/time_budget_widget.py
@@ -345,7 +345,7 @@ class timeBudgetResults(QWidget):
                 "Subject": str,
                 "Behavior": str,
                 "Modifiers": str,
-                "Total number of occurences": float,
+                "Total number of occurrences": float,
                 "Total duration (s)": float,
                 "Duration mean (s)": float,
                 "Duration std dev": float,
@@ -561,7 +561,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                         (
                                             "SELECT * FROM events "
                                             "WHERE observation = ? AND subject = ? AND code = ? AND modifiers = ? "
-                                            "AND occurence < ?"
+                                            "AND occurrence < ?"
                                         ),
                                         (obsId, subj, behav, modifier[0], min_time),
                                     ).fetchall()
@@ -569,7 +569,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                 % 2
                             ):
                                 cursor.execute(
-                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurence) VALUES (?,?,?,?,?,?)"),
+                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurrence) VALUES (?,?,?,?,?,?)"),
                                     (obsId, subj, behav, "STATE", modifier[0], min_time),
                                 )
 
@@ -578,7 +578,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                     cursor.execute(
                                         (
                                             "SELECT * FROM events WHERE observation = ? AND subject = ? AND code = ? "
-                                            "AND modifiers = ? AND occurence > ?"
+                                            "AND modifiers = ? AND occurrence > ?"
                                         ),
                                         (obsId, subj, behav, modifier[0], max_time),
                                     ).fetchall()
@@ -586,7 +586,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                 % 2
                             ):
                                 cursor.execute(
-                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurence) VALUES (?,?,?,?,?,?)"),
+                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurrence) VALUES (?,?,?,?,?,?)"),
                                     (obsId, subj, behav, "STATE", modifier[0], max_time),
                                 )
                         try:
@@ -598,7 +598,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
 
             # delete all events out of time interval from db
             cursor.execute(
-                "DELETE FROM events WHERE observation = ? AND (occurence < ? OR occurence > ?)",
+                "DELETE FROM events WHERE observation = ? AND (occurrence < ? OR occurrence > ?)",
                 (obsId, min_time, max_time),
             )
             try:
@@ -666,7 +666,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                 "Subject",
                 "Behavior",
                 "Modifiers",
-                "Total number of occurences",
+                "Total number of occurrences",
                 "Total duration (s)",
                 "Duration mean (s)",
                 "Duration std dev",
@@ -707,7 +707,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                     item = QTableWidgetItem(str(row["duration"]))
                 elif row["duration"] not in ("-", cfg.UNPAIRED) and not start_coding.is_nan():
                     tot_time = float(total_observation_time)
-                    # substract time of excluded behaviors from the total for the subject
+                    # subtract time of excluded behaviors from the total for the subject
                     if row["subject"] in excl_behaviors_total_time and row["behavior"] not in parameters[cfg.EXCLUDED_BEHAVIORS]:
                         tot_time -= excl_behaviors_total_time[row["subject"]]
                     item = QTableWidgetItem(f"{row['duration'] / tot_time * 100:.1f}" if tot_time > 0 else cfg.NA)
@@ -817,7 +817,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                 "Subject",
                 "Behavior",
                 "Modifiers",
-                "Total number of occurences",
+                "Total number of occurrences",
                 "Total duration (s)",
                 "Duration mean (s)",
                 "Duration std dev",
@@ -838,7 +838,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
             ]
 
         if mode == "by_category":
-            tb_fields = ["Subject", "Category", "Total number of occurences", "Total duration (s)"]
+            tb_fields = ["Subject", "Category", "Total number of occurrences", "Total duration (s)"]
             fields = ["subject", "category", "number", "duration"]
 
         mem_command = ""
@@ -894,7 +894,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                         (
                                             "SELECT * FROM events "
                                             "WHERE observation = ? AND subject = ? "
-                                            "AND code = ? AND modifiers = ? AND occurence < ?"
+                                            "AND code = ? AND modifiers = ? AND occurrence < ?"
                                         ),
                                         (obsId, subj, behav, modifier[0], min_time),
                                     ).fetchall()
@@ -902,7 +902,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                 % 2
                             ):
                                 cursor.execute(
-                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurence) VALUES (?,?,?,?,?,?)"),
+                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurrence) VALUES (?,?,?,?,?,?)"),
                                     (obsId, subj, behav, "STATE", modifier[0], min_time),
                                 )
                             if (
@@ -910,7 +910,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                     cursor.execute(
                                         (
                                             "SELECT * FROM events WHERE observation = ? AND subject = ? AND code = ?"
-                                            " AND modifiers = ? AND occurence > ?"
+                                            " AND modifiers = ? AND occurrence > ?"
                                         ),
                                         (obsId, subj, behav, modifier[0], max_time),
                                     ).fetchall()
@@ -918,7 +918,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                                 % 2
                             ):
                                 cursor.execute(
-                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurence) VALUES (?,?,?,?,?,?)"),
+                                    ("INSERT INTO events (observation, subject, code, type, modifiers, occurrence) VALUES (?,?,?,?,?,?)"),
                                     (obsId, subj, behav, cfg.STATE, modifier[0], max_time),
                                 )
                         try:
@@ -927,7 +927,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                             pass
 
             cursor.execute(
-                "DELETE FROM events WHERE observation = ? AND (occurence < ? OR occurence > ?)",
+                "DELETE FROM events WHERE observation = ? AND (occurrence < ? OR occurrence > ?)",
                 (obsId, min_time, max_time),
             )
 
@@ -980,7 +980,7 @@ def time_budget(self, mode: str, mode2: str = "list"):
                         values.append(row["duration"])
                     elif row["duration"] not in ("-", cfg.UNPAIRED) and not start_coding.is_nan():
                         tot_time = float(max_time - min_time)
-                        # substract duration of excluded behaviors from total time for each subject
+                        # subtract duration of excluded behaviors from total time for each subject
                         if row["subject"] in excl_behaviors_total_time and row["behavior"] not in parameters[cfg.EXCLUDED_BEHAVIORS]:
                             tot_time -= excl_behaviors_total_time[row["subject"]]
                         # % of tot time

--- a/boris/utilities.py
+++ b/boris/utilities.py
@@ -102,7 +102,7 @@ if (sys.platform.startswith("win") or sys.platform.startswith("linux")) and ("-i
             try:
                 from . import mpv2 as mpv
             except Exception:
-                logger.critical("MPV library not found after dowloading")
+                logger.critical("MPV library not found after downloading")
                 sys.exit(5)
 
         elif sys.platform.startswith("linux"):
@@ -404,7 +404,7 @@ def smart_time_format(sec: Union[float, dec], time_format: str = cfg.S, cutoff: 
     Smart time format
     returns time in seconds if <= cutoff else in HH:MM:SS.ZZZ format
     """
-    # cutoff = 0 follows the time format selectd by user
+    # cutoff = 0 follows the time format selected by user
     if cutoff == 0:
         return convertTime(time_format, sec)
     if sec <= cutoff:
@@ -458,7 +458,7 @@ def txt2np_array(
         column_converter (dict): dictionary key: column index, value: converter name
 
     Returns:
-        bool: True if data successfullly loaded, False if case of error
+        bool: True if data successfully loaded, False if case of error
         str: error message. Empty if success
         numpy array: data. Empty if not data failed to be loaded
 
@@ -538,7 +538,7 @@ def txt2np_array(
     except Exception:
         return False, f"{sys.exc_info()[1]}", np.array([])
 
-    # check if first value must be substracted
+    # check if first value must be subtracted
     if substract_first_value == "True":
         data[:, 0] -= data[:, 0][0]
 

--- a/changelog.md
+++ b/changelog.md
@@ -839,7 +839,7 @@ If you have an observation with many video players you must select the player yo
 
 * fixed bug when an observation is closed after state events reparation (Thanks to Haaken Zhong Bungum)
 
-* fix bug when ethogram, subjects list or independant variables list are edited after sorting (Thanks to Jana Muschinski)
+* fix bug when ethogram, subjects list or independent variables list are edited after sorting (Thanks to Jana Muschinski)
 
 
 **v. 7.9.8 2020-03-13**
@@ -900,7 +900,7 @@ If you have an observation with many video players you must select the player yo
 
 **v. 7.9 RC2 2019-10-24**
 
-* Added time budget bar plot for durations and number of occurences of behaviors
+* Added time budget bar plot for durations and number of occurrences of behaviors
 
 * Added behaviors defined as point event to the **Advanced event filtering** function
 
@@ -1903,7 +1903,7 @@ image::https://github.com/olivierfriard/boris_docs/blob/master/flow_diagram_grap
 
 * fixed behaviors colors in plot events  (https://github.com/olivierfriard/BORIS/issues/50)
 
-* fixed double "cariage return" bug when exporting plain text file on Windows 
+* fixed double "carriage return" bug when exporting plain text file on Windows 
 
 **2016-10-03 v. 2.995**
 
@@ -2045,7 +2045,7 @@ See **Tools -> Coding pad**
 
 **2015-12-02 v.2.7**
 
-* added sound spectrogram visualization during observation (FFmpeg framwork required)
+* added sound spectrogram visualization during observation (FFmpeg framework required)
 * added multi-editing function for events. Subject, behavior and comment fields can be edited for all the selected events.
 * added time offset feature in *plot events* function
 * added subjects and behaviors selection for the *export events* function
@@ -2188,7 +2188,7 @@ Bug fixed:
 
 * Added a parameters panel before plot events and time budget function in oreder to select subjects and behaviors to treat. This panel allows to include/exclude modifiers and include/exclude behaviors without events.
 
-* The % of total time changed in 'time budget' function, this value is now caculated using the total media duration (if available).
+* The % of total time changed in 'time budget' function, this value is now calculated using the total media duration (if available).
 
 * Added VIEWER mode when media file is no more available. Events can be created, modified, deleted but not logged from keyboard.
 
@@ -2202,7 +2202,7 @@ Bug fixed:
 
 **2015-06-14**
 
-* added sorting function for all fields in ethogram, subjects and indepedent variables tab in project window
+* added sorting function for all fields in ethogram, subjects and independent variables tab in project window
 * removed possibility to sort items manually
 * added VIEW mode to visualize/modify events of an observation without the corresponding media file
 * observed behaviors are now preselected in time budget and plot events functions
@@ -2631,6 +2631,6 @@ do not more return error if the code or subject in the edited event do not more 
 **2013-01-23**
 
 * reorganized the whole directory
-* add obs extension when project saved without extention when *.obs filter is active
+* add obs extension when project saved without extension when *.obs filter is active
 * edit project: check replace audio check box if necessary
 * edit project: check second video check box if necessary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 # Skip Qt-generated resource/UI code and the vendored python-mpv library
 # (kept in sync with tool.ruff.exclude above).
-skip = '.git,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*'
 check-hidden = true
 # ignore-regex = ''
 # fo - Windows `systeminfo /FO csv` output-format flag (not "for"/"of"/"to")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 # Skip Qt-generated resource/UI code and the vendored python-mpv library
 # (kept in sync with tool.ruff.exclude above).
-skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*,*/portion/*'
+skip = '.git,.git-meta,.gitignore,.gitattributes,.ruff_cache,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*,*/portion/*'
 check-hidden = true
 # ignore-regex = ''
 # fo - Windows `systeminfo /FO csv` output-format flag (not "for"/"of"/"to")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,10 @@ exclude = ["*_ui.py", "mpv*"]
 dev = [
     "pytest>=8.3.5",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.svg,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 # Skip Qt-generated resource/UI code and the vendored python-mpv library
 # (kept in sync with tool.ruff.exclude above).
-skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*,*/portion/*'
 check-hidden = true
 # ignore-regex = ''
 # fo - Windows `systeminfo /FO csv` output-format flag (not "for"/"of"/"to")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ dev = [
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.svg,*.lock'
+# Skip Qt-generated resource/UI code and the vendored python-mpv library
+# (kept in sync with tool.ruff.exclude above).
+skip = '.git,.gitignore,.gitattributes,*.svg,*.lock,*core_qrc.py,*_ui.py,mpv*'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# fo - Windows `systeminfo /FO csv` output-format flag (not "for"/"of"/"to")
+ignore-words-list = 'fo'

--- a/scripts/start_macOS.command
+++ b/scripts/start_macOS.command
@@ -29,7 +29,7 @@ else
     exit 1
 fi
 
-# We need to check for that specific binary; there are mutliple "xquartz" hits during startup
+# We need to check for that specific binary; there are multiple "xquartz" hits during startup
 # If checked for just "xquartz" it will match before the TCP is fully initialized and fail later
 isXQuartzRunning () {
     local xqProcesses

--- a/tests/test_db_functions.py
+++ b/tests/test_db_functions.py
@@ -23,7 +23,7 @@ class Test_load_events_in_db(object):
 
         cursor = db_functions.load_events_in_db(pj, ["subject1"], ["observation #1"], ["s"])
         cursor.execute(
-            "SELECT occurence FROM events WHERE observation = ? AND subject = ? AND code = ?",
+            "SELECT occurrence FROM events WHERE observation = ? AND subject = ? AND code = ?",
             ("observation #1", "subject1", "s"),
         )
         out = ""
@@ -37,7 +37,7 @@ class Test_load_events_in_db(object):
         pj = json.loads(open("files/test.boris").read())
 
         cursor = db_functions.load_events_in_db(pj, ["subject2"], ["live"], ["s", "p"])
-        cursor.execute("SELECT occurence FROM events WHERE observation = ? AND subject = ? AND code = ?", ("live", "subject2", "s"))
+        cursor.execute("SELECT occurrence FROM events WHERE observation = ? AND subject = ? AND code = ?", ("live", "subject2", "s"))
         out = ""
         for r in cursor.fetchall():
             out += "{}\n".format(r[0])
@@ -55,7 +55,7 @@ class Test_load_events_in_db(object):
 
         cursor = db_functions.load_events_in_db(pj, ["No focal subject"], ["live not paired"], ["s", "p"])
         cursor.execute(
-            "SELECT occurence FROM events WHERE observation = ? AND subject = ? AND code = ?",
+            "SELECT occurrence FROM events WHERE observation = ? AND subject = ? AND code = ?",
             ("live not paired", "No focal subject", "s"),
         )
         out = ""


### PR DESCRIPTION
Add [codespell](https://github.com/codespell-project/codespell) spell-checking
to BORIS: a small config in `pyproject.toml`, a lightweight GitHub Actions
workflow that only requires `contents: read`, and a one-time cleanup of ~150
existing typos across code, comments, docstrings, user-facing messages, and
`changelog.md`.

I've personally introduced codespell to over a hundred of projects with
mostly positive feedback — see
[improveit-dashboard](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)
for context.

## What's in each commit

| Commit | What |
|---|---|
| Add GitHub Actions workflow… | `.github/workflows/codespell.yml` — runs on push/PR to master, read-only permissions |
| Add rudimentary codespell config | Initial `[tool.codespell]` block in `pyproject.toml` |
| Expand codespell skip list… | Skip Qt-generated code (`*_ui.py`, `*core_qrc.py`) and vendored `python-mpv` (`mpv*`) to match `tool.ruff.exclude`; whitelist `fo` for the Windows `systeminfo /FO csv` flag in `boris/utilities.py` |
| Fix ambiguous typo: loggin -> logging | Manual fix in `boris/dialog.py` docstring — the next code line calls `logging.critical(...)` so intent is clear |
| [DATALAD RUNCMD] Fix non-ambiguous typos… | `codespell -w` pass across the tree (~147 fixes) recorded via `datalad run` so the exact command is reproducible |
| Skip vendored `portion` library | Revert one docstring fix in `boris/portion/dict.py` and extend skip with `*/portion/*` — same principle as the `mpv*` skip |
| Skip `.ruff_cache` in codespell | Silence local encoding warnings for the ruff cache directory |

## Categories of typos fixed

- **`occurence` / `occurences` / `occured`** → `occurrence` / `occurrences` / `occurred` — 93 fixes across `db_functions.py`, `events_snapshots.py`, `time_budget_functions.py`, `time_budget_widget.py`, `plot_events.py`, `dialog.py`, `converters.py`, etc.
- **`substract` / `substracted`** → `subtract` / `subtracted` — 11 fixes in comments and user-facing strings only. **Persistent config keys `SUBSTRACT_FIRST_EXIF_DATE`, `substract_first_value`, `PLOT_DATA_SUBSTRACT1STVALUE_IDX` in `boris/config.py` and `boris/plot_data_module.py` are left untouched** to preserve backwards compatibility with saved user projects.
- **`desactivate` → `deactivate`**, **`behviors` → `behaviors`**, **`begining` → `beginning`**, **`projet` → `project`**, **`longuest` → `longest`**, **`wih` → `with`**, **`ommitted` → `omitted`**, **`chek` → `check`**, **`independant`/`indipendent`/`indepedent` → `independent`**.
- **Single-instance fixes**: `succeded`, `successfullly`, `selectd`, `reding`, `operaton`, `mutliple`, `measurments`, `matchin`, `lables`, `issuses`, `framwork`, `extention`, `dowloading`, `convertion`, `cariage`, `caculated`, `behavioal`, `Retruns` → `Returns`, `PROJET` → `PROJECT`, `Modifiy` → `Modify`, `unvalidate` → `invalidate`.

<details>
<summary>SQL column rename note (safe?!) Let us know</summary>

`boris/db_functions.py` renames the SQLite column `occurence` → `occurrence` in the `CREATE TABLE`, `INSERT INTO`, `SELECT`, and `row["occurence"]` accesses. This is safe because the database is `:memory:` (or `/tmp/ramdisk/events.sqlite`) — created fresh on every run — and the corresponding test file `tests/test_db_functions.py` was updated in the same pass.

If you think it must not be done -- just let know and we will whitelist it and redo
</details>

<details>
<summary>Files intentionally skipped</summary>

- `boris/core_qrc.py` — Qt resource compiler output, 16k lines of encoded binary data
- `boris/*_ui.py` — generated from `boris/*.ui` by `pyside6-uic`
- `boris/mpv.py`, `boris/mpv2.py` — vendored [python-mpv](https://github.com/jaseg/python-mpv) library (typos including the deliberate `'It ded.'` string should go upstream, not be locally rewritten)
- `boris/portion/*` — vendored [portion](https://github.com/AlexandreDecan/portion) interval library
- `.ruff_cache` — local ruff cache (binary files)

These match `tool.ruff.exclude`'s treatment of the same files.

</details>

<details>
<summary>Notes for the maintainer</summary>

1. **`boris/observation.ui`** — `Substract first value` → `Subtract first value` in the Qt XML column header. The generated `boris/observation_ui.py` is skipped by codespell, so it retains the old string until regenerated with `pyside6-uic observation.ui > observation_ui.py`.

2. **`boris/dialog.py:101`** — the string `f"Error succeded at ..."` was auto-fixed by codespell to `f"Error succeeded at ..."`. Grammatically correct but semantically odd inside `global_error_message`; you may prefer to reword to `"Error occurred at ..."`.

3. **Out-of-scope typos codespell did not catch** (unchanged in this PR):
   - `boris/cooccurence.py` (filename + module + `get_cooccurence` function + `cfg` labels) should be `cooccurrence` — but renaming the module affects imports across `boris/connections.py`, `boris/menu_options.py`, and is a real refactor rather than a spell-check.
   - `substract_first_value`, `SUBSTRACT_FIRST_EXIF_DATE`, `PLOT_DATA_SUBSTRACT1STVALUE_IDX` — persistent config keys; safe to leave as-is (would need a migration to rename).

</details>

## Verification

- `uvx codespell` — exits 0 (zero errors)
- `uvx ruff check boris/` — pre-existing 25 errors are unchanged (unrelated to this PR)
- `tests/test_db_functions.py` updated in the same commit that renames the SQL column to keep tests in sync

The CI workflow (`.github/workflows/codespell.yml`) uses the pinned
`codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579` (v2.2)
and declares `permissions: contents: read`, so it can't modify the repo.

---

Generated with [Claude Code](https://claude.com/claude-code) and love to typos-free code.
